### PR TITLE
Use java-ecs-logging instead of logback logstash encoder

### DIFF
--- a/java/backend/build.gradle
+++ b/java/backend/build.gradle
@@ -11,7 +11,7 @@ jar {
 dependencies {
 	compile(
 			'org.springframework.boot:spring-boot-starter-web',
-			"net.logstash.logback:logstash-logback-encoder:${logbackEncoderVersion}",
+			"co.elastic.logging:logback-ecs-encoder:${javaEcsLoggingVersion}",
 			'org.springframework.boot:spring-boot-starter-actuator',
 			'org.jolokia:jolokia-core',
 			'mysql:mysql-connector-java', // MySQL Connector-J

--- a/java/backend/src/main/resources/logback-spring.xml
+++ b/java/backend/src/main/resources/logback-spring.xml
@@ -41,37 +41,8 @@
 			<fileNamePattern>${LOG_FILE}.json.%d{yyyy-MM-dd}.gz</fileNamePattern>
 			<maxHistory>7</maxHistory>
 		</rollingPolicy>
-		<encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-			<providers>
-				<mdc/>
-				<timestamp>
-					<timeZone>UTC</timeZone>
-				</timestamp>
-				<provider class="net.logstash.logback.composite.loggingevent.StackHashJsonProvider">
-					<exclusions>${STE_EXCLUSIONS}</exclusions>
-				</provider>
-				<stackTrace>
-					<throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
-						<inlineHash>true</inlineHash>
-						<exclusions>${STE_EXCLUSIONS}</exclusions>
-						<rootCauseFirst>true</rootCauseFirst>
-						<maxLength>3000</maxLength>
-					</throwableConverter>
-				</stackTrace>
-				<pattern>
-					<pattern>
-						{
-						"log.level": "%level",
-						"service.name": "${springAppName:-}",
-						"process.pid": "${PID:-}",
-						"thread": "%thread",
-						"class": "%logger",
-						"mdc": "%mdc",
-						"message": "%message"
-						}
-					</pattern>
-				</pattern>
-			</providers>
+		<encoder class="co.elastic.logging.logback.EcsEncoder">
+			<serviceName>${springAppName:-}</serviceName>
 		</encoder>
 	</appender>
 	​

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -2,6 +2,7 @@ buildscript {
 	ext {
 		springBootVersion = '2.1.8.RELEASE'
 		logbackEncoderVersion = '6.2'
+		javaEcsLoggingVersion = '0.1.0'
 	}
 	repositories {
 		mavenCentral()

--- a/java/frontend/build.gradle
+++ b/java/frontend/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 			'org.springframework.boot:spring-boot-starter-web',
 			'org.springframework.boot:spring-boot-devtools',
 			'org.springframework.boot:spring-boot-starter-thymeleaf',
-			"net.logstash.logback:logstash-logback-encoder:${logbackEncoderVersion}",
+			"co.elastic.logging:logback-ecs-encoder:${javaEcsLoggingVersion}",
 			'org.springframework.boot:spring-boot-starter-actuator',
 			'org.jolokia:jolokia-core'
 	)

--- a/java/frontend/src/main/resources/logback-spring.xml
+++ b/java/frontend/src/main/resources/logback-spring.xml
@@ -41,37 +41,8 @@
 			<fileNamePattern>${LOG_FILE}.json.%d{yyyy-MM-dd}.gz</fileNamePattern>
 			<maxHistory>7</maxHistory>
 		</rollingPolicy>
-		<encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-			<providers>
-				<mdc/>
-				<timestamp>
-					<timeZone>UTC</timeZone>
-				</timestamp>
-				<provider class="net.logstash.logback.composite.loggingevent.StackHashJsonProvider">
-					<exclusions>${STE_EXCLUSIONS}</exclusions>
-				</provider>
-				<stackTrace>
-					<throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
-						<inlineHash>true</inlineHash>
-						<exclusions>${STE_EXCLUSIONS}</exclusions>
-						<rootCauseFirst>true</rootCauseFirst>
-						<maxLength>3000</maxLength>
-					</throwableConverter>
-				</stackTrace>
-				<pattern>
-					<pattern>
-						{
-						"log.level": "%level",
-						"service.name": "${springAppName:-}",
-						"process.pid": "${PID:-}",
-						"thread": "%thread",
-						"class": "%logger",
-						"mdc": "%mdc",
-						"message": "%message"
-						}
-					</pattern>
-				</pattern>
-			</providers>
+		<encoder class="co.elastic.logging.logback.EcsEncoder">
+			<serviceName>${springAppName:-}</serviceName>
 		</encoder>
 	</appender>
 	​


### PR DESCRIPTION
Uses https://github.com/elastic/java-ecs-logging which makes the configuration a bit easier and makes the JSON ECS-compatible.